### PR TITLE
Fix issue with [7–10] like citations

### DIFF
--- a/src/Bibliography.js
+++ b/src/Bibliography.js
@@ -247,7 +247,7 @@ function parseFormattedCitationSequence (originalText, citations, formattedCitat
 		parts = splitLossless(text, formattedCitations).map(part => {
 			if (part.type === "delimiter") {
 				// Here delimiters are the actual citations
-				return {citation: citations[part.typeIndex], text: part.text};
+				return {citation: citations[part.patternIndex], text: part.text};
 			}
 			else {
 				return part.text;


### PR DESCRIPTION
We want anchors to the first and last items of the range, not the first and second.