### PR TITLE
Correctly handle sequences with the same citations but in a different order

### DIFF
--- a/src/Bibliography.js
+++ b/src/Bibliography.js
@@ -138,11 +138,14 @@ export default class Bibliography {
 
 		let parts = parseFormattedCitationSequence(text, citations);
 
-		if (parts === null) {
+		if (parts === null || parts.length > 3) {
 			// Sequence could not be parsed into parts directly
 			// Because not all citations are present in the output
 			// E.g. [1, 3–5, 18, 34–60]
 			// We need to help it along by serializing each citation individually and passing it to the function
+			// Why “parts.length > 3”? It covers cases like [1, 18, 32]. In those cases, we should follow this path too
+			// E.g. [@foo, @bar] and [@bar, @foo] might produce the same output — [1, 3]
+			// But “1” and “3” should be linked to different bibliography references in both cases
 			let formattedCitations = citations.map(c => {
 				let result = this.citeproc.appendCitationCluster({
 					citationItems: [c],

--- a/src/Bibliography.js
+++ b/src/Bibliography.js
@@ -138,13 +138,10 @@ export default class Bibliography {
 
 		let parts;
 		if (citations.length > 1) {
-			// Sequence cannot be parsed into parts directly
-			// Because not all citations are present in the output
-			// E.g. [1, 3–5, 18, 34–60]
-			// We need to help it along by serializing each citation individually and passing it to the function
-			// We should also correctly handle cases like [1, 18, 32]
-			// E.g. [@foo, @bar] and [@bar, @foo] might produce the same output — [1, 3]
-			// But “1” and “3” should be linked to different bibliography references in both cases
+			// Sequences should be handled differently because:
+			// — not all citations might be present in the output, e.g. [1, 3–5, 18, 34–60]
+			// — they might produce the same output but should be linked to different bibliography items, e.g., [@foo, @bar] and [@bar, @foo]
+			// So, we need to help it along by serializing each citation individually and passing it to the function
 			let formattedCitations = citations.map(c => {
 				let result = this.citeproc.appendCitationCluster({
 					citationItems: [c],

--- a/src/Bibliography.js
+++ b/src/Bibliography.js
@@ -138,12 +138,12 @@ export default class Bibliography {
 
 		let parts = parseFormattedCitationSequence(text, citations);
 
-		if (parts === null || parts.length > 3) {
+		if (citations.length > 1) {
 			// Sequence could not be parsed into parts directly
 			// Because not all citations are present in the output
 			// E.g. [1, 3–5, 18, 34–60]
 			// We need to help it along by serializing each citation individually and passing it to the function
-			// Why “parts.length > 3”? It covers cases like [1, 18, 32]. In those cases, we should follow this path too
+			// We should also correctly handle cases like [1, 18, 32]
 			// E.g. [@foo, @bar] and [@bar, @foo] might produce the same output — [1, 3]
 			// But “1” and “3” should be linked to different bibliography references in both cases
 			let formattedCitations = citations.map(c => {

--- a/src/Bibliography.js
+++ b/src/Bibliography.js
@@ -138,7 +138,7 @@ export default class Bibliography {
 
 		let parts;
 		if (citations.length > 1) {
-			// Sequence could not be parsed into parts directly
+			// Sequence cannot be parsed into parts directly
 			// Because not all citations are present in the output
 			// E.g. [1, 3–5, 18, 34–60]
 			// We need to help it along by serializing each citation individually and passing it to the function

--- a/src/Bibliography.js
+++ b/src/Bibliography.js
@@ -136,8 +136,7 @@ export default class Bibliography {
 			reference.citations.push(uuid);
 		}
 
-		let parts = parseFormattedCitationSequence(text, citations);
-
+		let parts;
 		if (citations.length > 1) {
 			// Sequence could not be parsed into parts directly
 			// Because not all citations are present in the output
@@ -155,6 +154,9 @@ export default class Bibliography {
 			});
 
 			parts = parseFormattedCitationSequence(text, citations, formattedCitations);
+		}
+		else {
+			parts = parseFormattedCitationSequence(text, citations);
 		}
 
 		let impliedCitations = citations.filter(c => !parts.some(part => part.citation === c));


### PR DESCRIPTION
Fixes #5